### PR TITLE
Treat minified files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat minified files as binary
+*.min.css binary


### PR DESCRIPTION
Diffs for minified files are pretty useless and don't communicate anything, we should make git aware of this at the repo level.