### PR TITLE
Limit to footnote link itself

### DIFF
--- a/src/css/parts/elements.css
+++ b/src/css/parts/elements.css
@@ -272,7 +272,7 @@
 		font-weight: var(--wght);
 	}
 
-	& a[href*="javascript"]::before,
+	& .footnote-footer > a[href*="javascript"]::before,
 	.bibitem::after {
 		--MONO: 1;
 		--wght: calc(var(--ui-wght) + 100);
@@ -295,7 +295,7 @@
 		margin: 0.25em 0 0 6ch;
 	}
 
-	& a[href*="javascript"] {
+	& .footnote-footer > a[href*="javascript"] {
 		&,
 		&:visited {
 			--MONO: 1;


### PR DESCRIPTION
Specified only the link of the footnote itself; so the selector doesn't apply on other a elements in the footnote like collapsibles

Also the `:is(.footnotes-footer, .bibitems)` tag specifies the child `a[href*=javascript]` which is not beneficial to bibitems since wikidot doesn't add a link to these anyways and are only added to footnotes (unless a user add one inside the contents of one, in which case we do not want to target nor affect); so I changed it to specify the child `.footnote-footer > a[href*=javascript]` hence only affecting the footnotes only

should not cause any issues with my testing